### PR TITLE
Allow floating point intervals

### DIFF
--- a/IntervalTree.js
+++ b/IntervalTree.js
@@ -108,14 +108,14 @@ IntervalTree.prototype.remove = function(interval_id) {
 function _insert(node, itvl) {
   if (itvl.end < node.idx) {
     if (!node.left) {
-      node.left = new Node(itvl.start + itvl.end >> 1, this);
+      node.left = new Node((itvl.start + itvl.end / 2), this);
     }
     return _insert.call(this, node.left, itvl);
   }
 
   if (node.idx < itvl.start) {
     if (!node.right) {
-      node.right = new Node(itvl.start + itvl.end >> 1, this);
+      node.right = new Node((itvl.start + itvl.end) / 2, this);
     }
     return _insert.call(this, node.right, itvl);
   }


### PR DESCRIPTION
I fixed #9 by replacing the bitwise division by two two a simple division by two, allowing for intervals with floating point bounds.