### PR TITLE
Fix typo in halving of interval on node insertion

### DIFF
--- a/IntervalTree.js
+++ b/IntervalTree.js
@@ -108,7 +108,7 @@ IntervalTree.prototype.remove = function(interval_id) {
 function _insert(node, itvl) {
   if (itvl.end < node.idx) {
     if (!node.left) {
-      node.left = new Node((itvl.start + itvl.end / 2), this);
+      node.left = new Node((itvl.start + itvl.end) / 2, this);
     }
     return _insert.call(this, node.left, itvl);
   }


### PR DESCRIPTION
In function `_insert()`, the midpoint of the interval was incorrectly
calculated for left-hand traversal as `itvl.start + itvl.end / 2`. This
causes infinite recursion whenever a node is inserted below a parent
where `itvl.end < idx` and `itvl.end < 2 * itvl.start`.
